### PR TITLE
Create new blog index and post templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,4 @@ github_username:  jekyll
 
 # Build settings
 markdown: kramdown
+permalink: pretty

--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -1,0 +1,24 @@
+<section id="blog" class="section blog">
+	<div class="container">
+		<div class="title">
+			<h1>BLOG</h1>
+			<div class="underline"></div>
+		</div>
+		<div class="posts">
+			<ul>
+			  {% for post in site.posts %}
+			    <li class="post">
+			    	<h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+			    	<p class="summary">
+			    		{{ post.categories }} &nbsp;|&nbsp;
+			    		<span class="date">
+			    			{{ post.date | date: '%B %d, %Y' }}
+			    		</span>
+			    	</p>
+			    	{{ post.excerpt }}
+			    </li>
+			  {% endfor %}
+			</ul>	
+		</div>
+	</div>
+</section>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,0 +1,14 @@
+<section class="post">
+	<div class="container">
+		<article>
+			<h1>{{ page.title }}</h1>
+			<div class="entry">
+	    		{{ content }}
+	  		</div>
+	  		<div class="date">
+	  			<p>{{ page.categories }}</p>
+	    		<p>Written on {{ page.date | date: "%B %e, %Y" }}</p>
+	  		</div>
+		</article>
+	</div>
+</section>	

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!--[if IE 8]> <html lang="en" class="ie8"> <![endif]-->
+<!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
+<!--[if !IE]><!--> <html lang="en"> <!--<![endif]-->
+{% include head.html %}
+<body data-spy="scroll">
+{% include facebook.html %}
+{% include header.html %}
+{% include blog.html %}
+{% include footer.html %}
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!--[if IE 8]> <html lang="en" class="ie8"> <![endif]-->
+<!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
+<!--[if !IE]><!--> <html lang="en"> <!--<![endif]-->
+{% include head.html %}
+<body data-spy="scroll">
+{% include facebook.html %}
+{% include header.html %}
+{% include post.html %}
+{% include footer.html %}
+</body>
+</html>

--- a/_posts/2016-12-28-sample-post.markdown
+++ b/_posts/2016-12-28-sample-post.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "Sample Post"
+date:   2016-12-28 18:30:39
+categories: test
+---
+You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve --watch`, which launches a web server and auto-regenerates your site when a file is updated.
+
+To add new posts, simply add a file in the `_posts` directory that follows the convention `YYYY-MM-DD-name-of-post.ext` and includes the necessary front matter. Take a look at the source for this post to get an idea about how it works.
+
+Jekyll also offers powerful support for code snippets:
+
+{% highlight ruby %}
+def print_hi(name)
+  puts "Hi, #{name}"
+end
+print_hi('Tom')
+#=> prints 'Hi, Tom' to STDOUT.
+{% endhighlight %}
+
+Check out the [Jekyll docs][jekyll] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll’s dedicated Help repository][jekyll-help].
+
+[jekyll]:      http://jekyllrb.com
+[jekyll-gh]:   https://github.com/jekyll/jekyll
+[jekyll-help]: https://github.com/jekyll/jekyll-help

--- a/_posts/2016-12-28-sample2.markdown
+++ b/_posts/2016-12-28-sample2.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "Sample Post 2"
+date:   2016-12-28 18:30:39
+categories: test
+---
+You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve --watch`, which launches a web server and auto-regenerates your site when a file is updated.
+
+To add new posts, simply add a file in the `_posts` directory that follows the convention `YYYY-MM-DD-name-of-post.ext` and includes the necessary front matter. Take a look at the source for this post to get an idea about how it works.
+
+Jekyll also offers powerful support for code snippets:
+
+{% highlight ruby %}
+def print_hi(name)
+  puts "Hi, #{name}"
+end
+print_hi('Tom')
+#=> prints 'Hi, Tom' to STDOUT.
+{% endhighlight %}
+
+Check out the [Jekyll docs][jekyll] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll’s dedicated Help repository][jekyll-help].
+
+[jekyll]:      http://jekyllrb.com
+[jekyll-gh]:   https://github.com/jekyll/jekyll
+[jekyll-help]: https://github.com/jekyll/jekyll-help

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,6 @@
+---
+title: openCypher Blog
+layout: blog
+permalink: /blog/
+sitemap: false
+---

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -609,6 +609,64 @@ pre code {
 .footer .fa-heart {
   color: #fb866a;
 }
+
+/* ======= Blog Index ======= */
+
+.blog {
+  padding: 80px 0;
+}
+
+.blog .title {
+  text-align: center;
+  margin: 40px 0 15px;
+}
+
+.blog .title h1 {
+  font-weight: 600;
+}
+
+.blog .title .underline {
+  height: 2px;
+  background: #e9e9e9;
+  width: 35px;
+  margin: 0 auto;
+}
+
+.blog ul {
+  padding: 0;
+  list-style: none;
+}
+
+.blog ul li {
+  padding: 25px 0;
+}
+
+.blog ul li h3 {
+  font-size: 26px;
+}
+
+.blog ul li .summary {
+  font-style: italic;
+  font-size: 14px;
+  margin-bottom: 20px;
+}
+
+/* ======= Posts ======= */
+
+.post {
+  padding: 80px 0;
+}
+
+.post article h1 {
+  margin: 40px 0 25px;
+}
+
+.post article .date {
+  font-style: italic;
+  font-size: 14px;
+  padding-top: 20px;
+}
+
 /* Extra small devices (phones, less than 768px) */
 @media (max-width: 767px) {
   .header .main-nav button {


### PR DESCRIPTION
This creates a new blog at: http://www.opencypher.org/blog/. 

There are an additional 2 seeded blog posts making a total of 3 example blog posts. There are templates for both the blog index and individual posts.

There is no link yet from the primary navigation.